### PR TITLE
ci: run the matrix once per commit, not twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 on:
   push:
+    branches:
+      - master
+    tags: '*'
   pull_request:
 concurrency:
   # Skip intermediate builds: always.


### PR DESCRIPTION
`on: push:` with no branch filter, alongside `pull_request:`, means every commit on a branch with an open pull request builds the whole matrix **twice** - once per event. Here that is 2 x 9 = **18 check runs per commit instead of 9**: double the runner minutes, a checks list where every entry appears twice with a `- push` / `- pull_request` suffix, and twice the webhook noise.

It also splits a re-run in half. On CompileMRI#10 I re-ran the failed jobs and half the checks stayed red, because the two events are separate runs and only one of them had been re-run.

Scoping push to `master` plus tags leaves pull request branches covered once by `pull_request`, and master and tags covered once by `push`.

    on:
      push:
        branches:
          - master
        tags: '*'
      pull_request:

This is what ROMEO.jl, MriResearchTools.jl and QuantitativeSusceptibilityMappingTGV.jl already do - CLEARSWI and CompileMRI were the two Julia packages still doubling up. CLEARSWI-Viewer is fine too; mritools-binaries had the same problem via `branches: ["**"]` and is fixed on its own branch.

The `concurrency` block below is unaffected: it cancels superseded runs within one event stream, and never deduplicated push against pull_request because their `github.ref` values differ.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7kdvZ4FQuvKFwBL735Sa7)_